### PR TITLE
bug fix, use --pbi in TCI wrapper

### DIFF
--- a/bin/task_pbccs_ccs
+++ b/bin/task_pbccs_ccs
@@ -54,6 +54,7 @@ def resolved_tool_contract_runner(rtc):
     assert output_file.endswith(".bam")
     args = [
         "ccs",
+        "--pbi",
         "--force",
         "--reportFile=%s" % rtc.task.output_files[1],
         "--numThreads=%d" % rtc.task.nproc,

--- a/src/main/ccs.cpp
+++ b/src/main/ccs.cpp
@@ -298,8 +298,8 @@ int main(int argc, char **argv)
     const vector<string> logLevels = { "TRACE", "DEBUG", "INFO", "NOTICE", "WARN", "ERROR", "CRITICAL", "FATAL" };
     const string em = "--";
 
-    parser.add_option(em + OptionNames::ForceOutput).action("store_true").help("Overwrite OUTPUT file if present.");
-    parser.add_option(em + OptionNames::PbIndex).action("store_true").help("Generate a .pbi file for the OUTPUT file.");
+    parser.add_option(em + OptionNames::ForceOutput).action("store_true").help("Overwrite OUTPUT file if present.").set_default("0");
+    parser.add_option(em + OptionNames::PbIndex).action("store_true").help("Generate a .pbi file for the OUTPUT file.").set_default("0");
     parser.add_option(em + OptionNames::Zmws).help("Generate CCS for the provided comma-separated holenumber ranges. Default = all");
     parser.add_option(em + OptionNames::MinSnr).type("float").set_default(4).help("Minimum SNR of input subreads. Default = %default");
     parser.add_option(em + OptionNames::MinReadScore).type("float").set_default(0.75).help("Minimum read score of input subreads. Default = %default");


### PR DESCRIPTION
Without the C++ changes, I get this:

terminate called after throwing an instance of 'optparse::InvalidValueCast'
  what():  invalid cast of Value
Aborted (core dumped)

which I suspect is caused by attempting to cast an empty string to a bool.  This is really a bug in cpp-optparse as far as I'm concerned.