### PR TITLE
list<OptionGroup const *> --> list<OptionGroup>

### DIFF
--- a/third-party/cpp-optparse/OptionParser.cpp
+++ b/third-party/cpp-optparse/OptionParser.cpp
@@ -176,7 +176,7 @@ OptionParser& OptionParser::add_option_group(const OptionGroup& group) {
     for (set<string>::const_iterator it = option._long_opts.begin(); it != option._long_opts.end(); ++it)
       _optmap_l[*it] = &option;
   }
-  _groups.push_back(&group);
+  _groups.push_back(group);
   return *this;
 }
 
@@ -305,13 +305,13 @@ Values& OptionParser::parse_args(const vector<string>& v) {
         _values[it->dest()] = it->get_default();
   }
 
-  for (list<OptionGroup const*>::iterator group_it = _groups.begin(); group_it != _groups.end(); ++group_it) {
-      for (strMap::const_iterator it = (*group_it)->_defaults.begin(); it != (*group_it)->_defaults.end(); ++it) {
+  for (list<OptionGroup>::iterator group_it = _groups.begin(); group_it != _groups.end(); ++group_it) {
+      for (strMap::const_iterator it = group_it->_defaults.begin(); it != group_it->_defaults.end(); ++it) {
           if (not _values.is_set(it->first))
               _values[it->first] = it->second;
       }
       
-      for (list<Option>::const_iterator it = (*group_it)->_opts.begin(); it != (*group_it)->_opts.end(); ++it) {
+      for (list<Option>::const_iterator it = group_it->_opts.begin(); it != group_it->_opts.end(); ++it) {
           if (it->get_default() != "" and not _values.is_set(it->dest()))
               _values[it->dest()] = it->get_default();
       }
@@ -396,8 +396,8 @@ string OptionParser::format_help() const {
   ss << _("Options") << ":" << endl;
   ss << format_option_help();
 
-  for (list<OptionGroup const*>::const_iterator it = _groups.begin(); it != _groups.end(); ++it) {
-    const OptionGroup& group = **it;
+  for (list<OptionGroup>::const_iterator it = _groups.begin(); it != _groups.end(); ++it) {
+    const OptionGroup& group = *it;
     ss << endl << "  " << group.title() << ":" << endl;
     if (group.group_description() != "")
       ss << str_format(group.group_description(), 4, cols()) << endl;

--- a/third-party/cpp-optparse/OptionParser.h
+++ b/third-party/cpp-optparse/OptionParser.h
@@ -229,7 +229,7 @@ class OptionParser {
     optMap _optmap_s;
     optMap _optmap_l;
     strMap _defaults;
-    std::list<OptionGroup const*> _groups;
+    std::list<OptionGroup> _groups;
 
     std::list<std::string> _remaining;
     std::list<std::string> _leftover;


### PR DESCRIPTION
I want to change the internal representation of OptionGroups from a list of pointers to a list of objects.  At a negligable performance cost we can clean-up how we use our OptionParsers:
(1) Separate Parser definitions from core logic
(2) Return to the original design of grouping options with the associated code
(3) Call and use the same parser for End-to-End testing without code duplication
(4) Still use OptionGroups for logic grouping and clean visual display of options