### PR TITLE
Fixing subtle pointer-bug introduced by my previous change

### DIFF
--- a/third-party/cpp-optparse/OptionParser.cpp
+++ b/third-party/cpp-optparse/OptionParser.cpp
@@ -170,9 +170,9 @@ Option& OptionParser::add_option(const vector<string>& v) {
 
 OptionParser& OptionParser::add_option_group(const OptionGroup& group) {
   _groups.push_back(group);
-  OptionGroup* currentGroup = &_groups.back();
+  OptionGroup& currentGroup = _groups.back();
 
-  for (list<Option>::const_iterator oit = currentGroup->_opts.begin(); oit != currentGroup->_opts.end(); ++oit) {
+  for (list<Option>::const_iterator oit = currentGroup._opts.begin(); oit != currentGroup._opts.end(); ++oit) {
     const Option& option = *oit;
     for (set<string>::const_iterator it = option._short_opts.begin(); it != option._short_opts.end(); ++it)
       _optmap_s[*it] = &option;

--- a/third-party/cpp-optparse/OptionParser.cpp
+++ b/third-party/cpp-optparse/OptionParser.cpp
@@ -169,14 +169,17 @@ Option& OptionParser::add_option(const vector<string>& v) {
 }
 
 OptionParser& OptionParser::add_option_group(const OptionGroup& group) {
-  for (list<Option>::const_iterator oit = group._opts.begin(); oit != group._opts.end(); ++oit) {
+  _groups.push_back(group);
+  OptionGroup* currentGroup = &_groups.back();
+
+  for (list<Option>::const_iterator oit = currentGroup->_opts.begin(); oit != currentGroup->_opts.end(); ++oit) {
     const Option& option = *oit;
     for (set<string>::const_iterator it = option._short_opts.begin(); it != option._short_opts.end(); ++it)
       _optmap_s[*it] = &option;
     for (set<string>::const_iterator it = option._long_opts.begin(); it != option._long_opts.end(); ++it)
       _optmap_l[*it] = &option;
   }
-  _groups.push_back(group);
+
   return *this;
 }
 


### PR DESCRIPTION
Last change to OptParse introduced a subtle bug because it also stored pointers directly to the elements of the OptionGroup as it was added, instead of the copy internal to the Parser.  This fixes it.