### PR TITLE
miscellaneous maintenance changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,14 +128,14 @@ endif(HAS_NO_UNUSED_VARIABLE)
 if (NOT PBBAM_INCLUDE_DIRS OR
     NOT PBBAM_LIBRARIES)
     add_subdirectory(${PacBioBAM_RootDir} external/pbbam/build EXCLUDE_FROM_ALL)
-    set(PBBAM_INCLUDE_DIRS ${PacBioBAM_IncludeDir} CACHE INTERNAL "" FORCE)
-    set(PBBAM_LIBRARIES pbbam CACHE INTERNAL "" FORCE)
+    set(PBBAM_INCLUDE_DIRS ${PacBioBAM_IncludeDir})
+    set(PBBAM_LIBRARIES pbbam)
 endif()
 
 if (NOT PBCONSENSUS_INCLUDE_DIRS OR
     NOT PBCONSENSUS_LIBRARIES)
     add_subdirectory(${PacBioConsensus_RootDir} external/ConsensusCore2/build EXCLUDE_FROM_ALL)
-    set(PBCONSENSUS_INCLUDE_DIRS ${PacBioConsensus_IncludeDir} CACHE INTERNAL "" FORCE)
+    set(PBCONSENSUS_INCLUDE_DIRS ${PacBioConsensus_IncludeDir})
 endif()
 
 # main exe src

--- a/include/pacbio/ccs/Consensus.h
+++ b/include/pacbio/ccs/Consensus.h
@@ -205,7 +205,7 @@ public:
         NonConvergent += other.NonConvergent;
         PoorQuality += other.PoorQuality;
         ExceptionThrown += other.ExceptionThrown;
-        
+
         return *this;
     }
 
@@ -515,19 +515,17 @@ ResultType<TResult> Consensus(std::unique_ptr<std::vector<TChunk>>& chunksRef,
             results.Success += 1;
             results.emplace_back(TResult{chunk.Id, std::string(ai), QVsToASCII(qvs), nPasses,
                                          predAcc, zAvg, zScores, statusCounts, nTested, nApplied,
-                                         chunk.SignalToNoise, timer.ElapsedMilliseconds(), chunk.Barcodes});
-        }
-        catch (const std::exception &exc) {
+                                         chunk.SignalToNoise, timer.ElapsedMilliseconds(),
+                                         chunk.Barcodes});
+        } catch (const std::exception& e) {
             results.ExceptionThrown += 1;
-            PBLOG_ERROR << "Skipping " << chunk.Id << ", caught exception during processing"
-                        << "\nException was: " << exc.what();
-
-        }
-        catch (...) {
-            // This should NEVER happen.  Only here as a guard, if this is ever printed someone goofed
+            PBLOG_ERROR << "Skipping " << chunk.Id << ", caught exception: '" << e.what() << "\'";
+        } catch (...) {
+            // This should NEVER happen. Only here as a guard, if this is ever printed someone
+            // goofed
             // up by throwing something that didn't derive from std::exception.
             results.ExceptionThrown += 1;
-            PBLOG_ERROR << "Skipping " << chunk.Id << ", caught unknown exception type during processing";
+            PBLOG_ERROR << "Skipping " << chunk.Id << ", caught unknown exception type";
         }
     }
 

--- a/include/pacbio/ccs/Consensus.h
+++ b/include/pacbio/ccs/Consensus.h
@@ -227,16 +227,15 @@ float Median(std::vector<T>* vs)
     return 0.5 * (vs->at(n / 2 - 1) + vs->at(n / 2));
 }
 
-
-    
 template <typename TRead>
-std::pair<std::vector<const TRead*>, size_t> FilterReads(const std::vector<TRead>& reads, const size_t minLength)
+std::vector<const TRead*> FilterReads(const std::vector<TRead>& reads, const size_t minLength,
+                                      int32_t* nFiltered)
 {
     // This is a count of subreads removed for bing too short, or too long.
-    size_t size_filtered_reads = 0;
+    *nFiltered = 0;
     std::vector<const TRead*> results;
 
-    if (reads.empty()) return std::make_pair(results, size_filtered_reads);
+    if (reads.empty()) return results;
 
     std::vector<size_t> lengths;
     size_t longest = 0;
@@ -254,8 +253,8 @@ std::pair<std::vector<const TRead*>, size_t> FilterReads(const std::vector<TRead
 
     // if it's too short, return nothing
     if (median < static_cast<float>(minLength)) {
-        size_filtered_reads += reads.size();
-        return std::make_pair(results, size_filtered_reads);
+        *nFiltered += reads.size();
+        return results;
     }
     results.reserve(reads.size());
 
@@ -264,10 +263,9 @@ std::pair<std::vector<const TRead*>, size_t> FilterReads(const std::vector<TRead
         //   otherwise it's twice the longest read and is always true
         if (read.Seq.length() < maxLen) {
             results.emplace_back(&read);
-        }
-        else {
+        } else {
             results.emplace_back(nullptr);
-            size_filtered_reads++;
+            (*nFiltered)++;
         }
     }
 
@@ -295,7 +293,7 @@ std::pair<std::vector<const TRead*>, size_t> FilterReads(const std::vector<TRead
                          return lexForm(lhs) > lexForm(rhs);
                      });
 
-    return std::make_pair(results, size_filtered_reads);
+    return results;
 }
 
 template <typename TRead>
@@ -402,11 +400,9 @@ ResultType<TResult> Consensus(std::unique_ptr<std::vector<TChunk>>& chunksRef,
             Timer timer;
             constexpr auto SIZE_FILTER = static_cast<size_t>(AddReadResult::OTHER) + 1;
             std::vector<int32_t> statusCounts(SIZE_FILTER + 1, 0);
-            
-            auto readsAndFilteredCount = FilterReads(chunk.Reads, settings.MinLength);
-            auto reads = readsAndFilteredCount.first;
-            statusCounts[SIZE_FILTER] += readsAndFilteredCount.second;
-            
+
+            auto reads = FilterReads(chunk.Reads, settings.MinLength, &statusCounts[SIZE_FILTER]);
+
             if (reads.empty() ||
                 std::accumulate(reads.begin(), reads.end(), 0, std::plus<bool>()) == 0) {
                 results.NoSubreads += 1;

--- a/src/main/ccs.cpp
+++ b/src/main/ccs.cpp
@@ -145,7 +145,7 @@ void WriteBamRecords(BamWriter& ccsBam, unique_ptr<PbiBuilder>& ccsPbi, Results&
 
 #if DIAGNOSTICS
         if (ccs.Barcodes) {
-            vector<uint16_t> bcs {ccs.Barcodes->first, ccs.Barcodes->second};
+            vector<uint16_t> bcs{ccs.Barcodes->first, ccs.Barcodes->second};
             tags["bc"] = bcs;
         }
         tags["ms"] = ccs.ElapsedMilliseconds;
@@ -175,10 +175,11 @@ Results BamWriterThread(WorkQueue<Results>& queue, unique_ptr<BamWriter>&& ccsBa
 void WriteFastqRecords(ofstream& ccsFastq, Results& counts, Results&& results)
 {
     counts += results;
-    for (const auto& ccs : results) {        ccsFastq << '@' << *(ccs.Id.MovieName) << '/' << ccs.Id.HoleNumber << "/ccs"
-        << " np:i:" << ccs.NumPasses << " rq:f:" << ccs.PredictedAccuracy;
+    for (const auto& ccs : results) {
+        ccsFastq << '@' << *(ccs.Id.MovieName) << '/' << ccs.Id.HoleNumber << "/ccs"
+                 << " np:i:" << ccs.NumPasses << " rq:f:" << ccs.PredictedAccuracy;
 #if DIAGNOSTICS
-        if( ccs.Barcodes) {
+        if (ccs.Barcodes) {
             ccsFastq << " bc:" << ccs.Barcodes->first << "-" << ccs.Barcodes->second;
         }
 #endif
@@ -272,10 +273,9 @@ void WriteResultsReport(ostream& report, const Results& counts)
 
     report << "Failed -- CCS below minimum predicted accuracy," << counts.PoorQuality << ","
            << 100.0 * counts.PoorQuality / total << '%' << endl;
-    
+
     report << "Failed -- Exception thrown during processing," << counts.ExceptionThrown << ","
            << 100.0 * counts.ExceptionThrown / total << '%' << endl;
-    
 }
 
 int main(int argc, char** argv)
@@ -466,7 +466,6 @@ int main(int argc, char** argv)
         }
         // Have we started a new ZMW?
         if (!holeNumber || *holeNumber != read.HoleNumber()) {
-            
             if (chunk && !chunk->empty() && chunk->back().Reads.size() < settings.MinPasses) {
                 PBLOG_DEBUG << "Skipping ZMW " << chunk->back().Id
                             << ", insufficient number of passes (" << chunk->back().Reads.size()
@@ -482,7 +481,7 @@ int main(int argc, char** argv)
 
             holeNumber = read.HoleNumber();
             auto snr = read.SignalToNoise();
-            if(read.HasBarcodes()) {
+            if (read.HasBarcodes()) {
                 barcodes = read.Barcodes();
             }
             if (whitelist && !whitelist->Contains(movieName, *holeNumber)) {
@@ -510,8 +509,7 @@ int main(int argc, char** argv)
         // Check that barcode matches the previous ones
         if (barcodes) {
             // if not, set the barcodes to the flag and stop checking them.
-            if(!read.HasBarcodes() || read.Barcodes() != barcodes) {
-                
+            if (!read.HasBarcodes() || read.Barcodes() != barcodes) {
                 barcodes->first = UINT16_MAX;
                 barcodes->second = UINT16_MAX;
                 chunk->back().Barcodes = barcodes;

--- a/tests/TestConsensus.cpp
+++ b/tests/TestConsensus.cpp
@@ -48,30 +48,27 @@ typedef ReadType<ReadId> Subread;
 TEST(ConsensusTest, TestReadFilter)
 {
     std::vector<Subread> data;
-    std::string fullRead = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    std::string seq =
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     auto movieName = std::make_shared<std::string>("fakeName");
     LocalContextFlags flags = LocalContextFlags::ADAPTER_BEFORE | LocalContextFlags::ADAPTER_AFTER;
-    for(int i=0; i<10; i++) {
-
-    auto read = Subread{ReadId(movieName, 1,
-                    Interval(0, fullRead.size())),
-                    fullRead, flags, .99};
-    data.emplace_back(read);
+    for (int i = 0; i < 10; i++) {
+        data.emplace_back(
+            Subread{ReadId(movieName, 1, Interval(0, seq.size())), seq, flags, .99});
     }
     // Nothing filtered
-    auto result = FilterReads(data, 10);
-    EXPECT_EQ(0, result.second);
-    
-    // All removed
-    auto result2 = FilterReads(data, 1000);
-    EXPECT_EQ(10, result2.second);
-    
-    // Just one 
-    auto longRead = fullRead + fullRead + fullRead;
-    data.emplace_back(Subread{ReadId(movieName, 1,
-                    Interval(0, fullRead.size())),
-                    longRead, flags, .99});
-    auto result3 = FilterReads(data, 10);
-    EXPECT_EQ(1, result3.second);
+    int32_t nFiltered;
+    auto result = FilterReads(data, 10, &nFiltered);
+    EXPECT_EQ(0, nFiltered);
 
+    // All removed
+    auto result2 = FilterReads(data, 1000, &nFiltered);
+    EXPECT_EQ(10, nFiltered);
+
+    // Just one
+    auto longSeq = seq + seq + seq;
+    data.emplace_back(
+        Subread{ReadId(movieName, 1, Interval(0, longSeq.size())), longSeq, flags, .99});
+    auto result3 = FilterReads(data, 10, &nFiltered);
+    EXPECT_EQ(1, nFiltered);
 }

--- a/tests/TestConsensus.cpp
+++ b/tests/TestConsensus.cpp
@@ -33,8 +33,6 @@
 // OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 // SUCH DAMAGE.
 
-
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <pacbio/ccs/Consensus.h>
@@ -53,8 +51,7 @@ TEST(ConsensusTest, TestReadFilter)
     auto movieName = std::make_shared<std::string>("fakeName");
     LocalContextFlags flags = LocalContextFlags::ADAPTER_BEFORE | LocalContextFlags::ADAPTER_AFTER;
     for (int i = 0; i < 10; i++) {
-        data.emplace_back(
-            Subread{ReadId(movieName, 1, Interval(0, seq.size())), seq, flags, .99});
+        data.emplace_back(Subread{ReadId(movieName, 1, Interval(0, seq.size())), seq, flags, .99});
     }
     // Nothing filtered
     int32_t nFiltered;

--- a/third-party/cpp-optparse/OptionParser.h
+++ b/third-party/cpp-optparse/OptionParser.h
@@ -60,16 +60,18 @@
 #ifndef OPTIONPARSER_H_
 #define OPTIONPARSER_H_
 
-#include <string>
-#include <vector>
+#include <algorithm>
+#include <cctype>
+#include <iostream>
+#include <limits>
 #include <list>
 #include <map>
 #include <set>
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
-#include <limits>
+#include <vector>
 
 namespace optparse {
 
@@ -107,16 +109,17 @@ class Value {
     template<typename T,
              typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
     operator T() {
-        T t;        
-        if (valid && (std::istringstream(str) >> t)) {
+        T t;
+        if (valid && (std::istringstream(str) >> t))
             return t;
-        } else if (std::is_floating_point<T>::value)
+        else if (valid && std::is_floating_point<T>::value)
         {
-            // Hacky work around for NaN values, istringstream
-            // only handles this in some implementations.
-            if (str == "NaN" || str == "nan") {
+            std::string lc(str);
+            std::transform(lc.begin(), lc.end(), lc.begin(), ::tolower);
+            if (lc == "inf")
+                return std::numeric_limits<T>::infinity();
+            else if (lc == "nan")
                 return std::numeric_limits<T>::quiet_NaN();
-            }
         }
         throw InvalidValueCast();
     }


### PR DESCRIPTION
- revise the FilterReads API (pairs + auto are ugly, C++11 get proper type unification please)
- fix CMake CACHE issue for config'd rebuilds
- newlines in log messages are not advised, apparently
- camelCase
- trailing whitespace
- clang-format'ting