### PR TITLE
Python tool contract wrapper cleanup

### DIFF
--- a/bin/task_pbccs_ccs
+++ b/bin/task_pbccs_ccs
@@ -18,7 +18,7 @@ from pbcommand.models.report import Report, Attribute
 from pbcommand.cli import pbparser_runner
 from pbcommand.utils import setup_log
 from pbcommand.engine import run_cmd
-from pbcore.io import SubreadSet, ConsensusReadSet
+from pbcore.io import ConsensusReadSet
 
 __version__ = "0.1"
 log = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ def resolved_tool_contract_runner(rtc):
     Run the ccs binary from the resolved tool contract, and generate an XML
     dataset around the resulting .bam file.
     """
-    ds = SubreadSet(rtc.task.input_files[0])
+    subreads_file = rtc.task.input_files[0]
     output_file = rtc.task.output_files[0]
     if output_file.endswith(".consensusreadset.xml"):
         output_file = re.sub(".consensusreadset.xml", ".bam", output_file)
@@ -96,30 +96,8 @@ def resolved_tool_contract_runner(rtc):
             rtc.task.options[Constants.MIN_PREDICTED_ACCURACY_ID],
         "--noPolish" if rtc.task.options[Constants.NO_POLISH_ID] else "",
         output_file,
+        subreads_file
     ]
-    zmwRanges = ds.zmwRanges
-    if len(zmwRanges) > 0:
-        movie_ids = set([m for (m, s, e) in zmwRanges])
-        # XXX this restriction could go away in the future but in practice it
-        # will probably always be satisfied anyway
-        assert len(movie_ids) == 1, \
-            "ZMW ranges restricted to a single movie at present."
-        args.append("--zmws=" +
-                    ",".join(["%d-%d" % (s, e) for (m, s, e) in zmwRanges]))
-        # TODO let the C++ side handle some of this
-        # args.append("--zmws=" + zmwRanges[0][0] + ":" +
-        #            ",".join([ "%d-%d" % (s,e) for (m,s,e) in zmwRanges ]))
-        # XXX hack to make sure we only pass the names of files that contain
-        # reads from the specified movie
-        movie_id = list(movie_ids)[0]
-        for bam in ds.resourceReaders():
-            for rg in bam.readGroupTable:
-                if rg.MovieName == movie_id:
-                    args.append(bam.filename)
-                    break
-    else:
-        args.extend(ds.toExternalFiles())
-    ds.close()
     logging.info(" ".join(args))
     result = run_cmd(
         cmd=" ".join(args),

--- a/tests/python/test_tool_contract.py
+++ b/tests/python/test_tool_contract.py
@@ -1,24 +1,29 @@
 #!/usr/bin/env python
 
 """
-Test for tool contract interface support.
+Test for tool contract interface support, using a SubreadSet with filters
+applied as input.
 """
 
-import os
+import logging
+import tempfile
 import unittest
 import os.path as op
+import os
 
 import pbcommand.testkit
 import pbcore.data
-from pbcore.io import ConsensusReadSet
+from pbcore.io import ConsensusReadSet, SubreadSet
 
+logging.basicConfig(level=logging.INFO)
 CCS_DIR = op.dirname(op.dirname(op.dirname(__file__)))
+CHUNK_INDEX = 1
 
 class TestCCSApp(pbcommand.testkit.PbTestApp):
     # FIXME eventually the 'ccs' binary should handle TCI directly
     DRIVER_BASE = op.join(CCS_DIR, "bin", "task_pbccs_ccs")
     REQUIRES_PBCORE = True
-    INPUT_FILES = [ pbcore.data.getUnalignedBam() ]
+    INPUT_FILES = [tempfile.NamedTemporaryFile(suffix=".subreadset.xml").name]
     TASK_OPTIONS = {
         "pbccs.task_options.min_snr": 3,
         "pbccs.task_options.min_read_score": 0.75,
@@ -29,11 +34,28 @@ class TestCCSApp(pbcommand.testkit.PbTestApp):
         "pbccs.task_options.no_polish": True,
     }
 
+    def setUp(self):
+        BAM_IN = pbcore.data.getUnalignedBam()
+        ds = SubreadSet(BAM_IN, strict=True)
+        chunks = ds.split(zmws=True, chunks=2, targetSize=2)
+        assert len(chunks) == 2
+        logging.info("zmwRanges[CHUNK_INDEX] = {r}".format(
+            r=str(chunks[CHUNK_INDEX].zmwRanges)))
+        logging.info("SubreadSet = {f}".format(f=self.INPUT_FILES[0]))
+        chunks[CHUNK_INDEX].write(self.INPUT_FILES[0])
+        #tf = tempfile.NamedTemporaryFile(suffix=".subreadset.xml").name
+        #print tf
+        #chunks[int(not CHUNK_INDEX)].write(tf)
+
     def run_after(self, rtc, output_dir):
         with ConsensusReadSet(rtc.task.output_files[0]) as ds_out:
-            self.assertEqual(len(ds_out), 3)
+            zmws = set(ds_out.resourceReaders()[0].holeNumber)
+            logging.info("ZMWs = {z}".format(z=zmws))
+            self.assertEqual(zmws, set([32861, 37134]))
+
 
 if __name__ == "__main__":
     # add this to the environment to run the test locally
-    os.environ['__PBTEST_CCS_EXE'] = op.join(CCS_DIR, "bin", "ccs")
+    if not "__PBTEST_CCS_EXE" in os.environ:
+        os.environ['__PBTEST_CCS_EXE'] = op.join(CCS_DIR, "bin", "ccs")
     unittest.main()

--- a/tests/python/test_tool_contract.py
+++ b/tests/python/test_tool_contract.py
@@ -39,6 +39,7 @@ class TestCCSApp(pbcommand.testkit.PbTestApp):
         ds = SubreadSet(BAM_IN, strict=True)
         chunks = ds.split(zmws=True, chunks=2, targetSize=2)
         assert len(chunks) == 2
+        self.zmw_range = chunks[CHUNK_INDEX].zmwRanges[0][1:3]
         logging.info("zmwRanges[CHUNK_INDEX] = {r}".format(
             r=str(chunks[CHUNK_INDEX].zmwRanges)))
         logging.info("SubreadSet = {f}".format(f=self.INPUT_FILES[0]))
@@ -51,7 +52,8 @@ class TestCCSApp(pbcommand.testkit.PbTestApp):
         with ConsensusReadSet(rtc.task.output_files[0]) as ds_out:
             zmws = set(ds_out.resourceReaders()[0].holeNumber)
             logging.info("ZMWs = {z}".format(z=zmws))
-            self.assertEqual(zmws, set([32861, 37134]))
+            for z in zmws:
+                self.assertTrue(self.zmw_range[0] < z < self.zmw_range[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I removed the custom filter code and now pass the SubreadSet directly to 'ccs'; I've also modified the TC test to generate a filtered SubreadSet and verify that the output is consistent with filters.