### PR TITLE
Tweak unsupported chemistry error to be more informative

### DIFF
--- a/src/main/ccs.cpp
+++ b/src/main/ccs.cpp
@@ -461,7 +461,8 @@ int main(int argc, char** argv)
                        back_inserter(unavail));
 
         if (!unavail.empty()) {
-            PBLOG_FATAL << "Unsupported chemistries found: " << join(unavail, ", ");
+            PBLOG_FATAL << "Unsupported chemistries found: \"" << join(unavail, "\", \"") << "\""
+                << " Supported chemistries are: \"" << join(avail, "\", \"") << "\"";
             exit(-1);
         }
 


### PR DESCRIPTION
Quote chemistry names in error message given when chemistry is unrecognised and dump list of available supported chemistry options.